### PR TITLE
Revert "ArtifactType updated to org.cncf.notary.v2"

### DIFF
--- a/registry/mediatype.go
+++ b/registry/mediatype.go
@@ -2,7 +2,7 @@ package registry
 
 const (
 	// ArtifactTypeNotation specifies the artifact type for a notation object.
-	ArtifactTypeNotation = "org.cncf.notary.v2"
+	ArtifactTypeNotation = "application/vnd.cncf.notary.v2"
 )
 
 const (


### PR DESCRIPTION
Reverts shizhMSFT/notation-go-lib#3 

Please squash merge/revert this change as needed. 
This is as per discussion on the call today to keep the artifactType as a media type as per - 
https://github.com/oras-project/artifacts-spec/pull/39/files